### PR TITLE
Generalized ORM

### DIFF
--- a/dba/document_orm.go
+++ b/dba/document_orm.go
@@ -6,8 +6,9 @@ import (
 	"github.com/blevesearch/bleve/document"
 )
 
-// resultsMapFromDocument builds a results object.
-func resultsMapFromDocument(doc *document.Document) (map[string]interface{}, error) {
+// MakeMapFromDocument builds a results object. This is a generally useful
+// ORM-like function for any document obtained from bleve.
+func MakeMapFromDocument(doc *document.Document) (map[string]interface{}, error) {
 	resultsMap := make(map[string]interface{})
 	allerrors := make([]error, 0)
 
@@ -30,6 +31,7 @@ func resultsMapFromDocument(doc *document.Document) (map[string]interface{}, err
 			}
 			resultsMap[t.Name()] = v
 		case *document.TextField:
+			// TODO(rjk): Is there a way to not convert this into a string?
 			resultsMap[t.Name()] = string(t.Value())
 		case *document.DateTimeField:
 			v, err := t.DateTime()

--- a/dba/document_orm_test.go
+++ b/dba/document_orm_test.go
@@ -1,0 +1,153 @@
+package dba
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/blevesearch/bleve"
+	"github.com/blevesearch/bleve/analysis/analyzers/keyword_analyzer"
+	"github.com/pborman/uuid"
+	"github.com/sfbrigade/sfsbook/dba/fieldmap"
+)
+
+// TestDatabaseType implements IndexFactory for test data.
+type TestDatabaseType struct {
+	name string
+	data []map[string]interface{}
+}
+
+func (g *TestDatabaseType) Name() string {
+	return g.name
+}
+
+func buildTestDocumentMapping() *bleve.DocumentMapping {
+	numberMapping := bleve.NewNumericFieldMapping()
+
+	// testDocumentMapping is a document mapping for tests.
+	testDocumentMapping := bleve.NewDocumentMapping()
+	testDocumentMapping.DefaultAnalyzer = keyword_analyzer.Name
+
+	testDocumentMapping.AddFieldMappingsAt("textfield", fieldmap.KeywordFieldMapping)
+	testDocumentMapping.AddFieldMappingsAt("numberfield", numberMapping)
+	testDocumentMapping.AddFieldMappingsAt("datefield", fieldmap.DateTimeMapping)
+	testDocumentMapping.AddFieldMappingsAt("istruefield", fieldmap.BoolFieldMapping)
+
+	return testDocumentMapping
+}
+
+// Need a mapping for each type.
+func (_ TestDatabaseType) Mapping() *bleve.IndexMapping {
+	return fieldmap.AllDocumentMapping(fieldmap.IndexDocumentMap{
+		"testdoc": buildTestDocumentMapping(),
+	})
+}
+
+func (g *TestDatabaseType) LoadStartData(i bleve.Index, pathroot string) error {
+	s := g.data
+
+	batch := i.NewBatch()
+	for _, r := range s {
+		rid := uuid.NewRandom()
+		r["_type"] = "testdoc"
+		batch.Index(string(rid), r)
+	}
+
+	if err := i.Batch(batch); err != nil {
+		return err
+	}
+	return nil
+}
+
+func TestMakeMapFromDocument(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "dba")
+	// log.Println(tmpdir)
+	if err != nil {
+		t.Fatal("can't make a temporary directory", err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	// NB: the '_' precluded the use of an MatchQuery. This
+	// suggests that I should change password search to Term.
+	testfilesetup := &TestDatabaseType{
+		name: "test.bleve",
+		data: []map[string]interface{}{
+			map[string]interface{}{
+				"textfield":   "string_value",
+				"numberfield": 100.1,
+				"datefield":   time.Unix(1000, 0),
+				"istruefield": true,
+			},
+			map[string]interface{}{
+				"textfield":   "second_string_value",
+				"numberfield": 200.1,
+				"datefield":   time.Unix(2000, 0),
+				"istruefield": false,
+			},
+		},
+	}
+
+	// Open and populate a database.
+	db, err := OpenBleve(tmpdir, testfilesetup)
+	if err != nil {
+		t.Fatal("OpenBleve failed to add a test database", err)
+	}
+
+	// Records exist.
+	if n, err := db.DocCount(); n != 2 || err != nil {
+		t.Error("expected to find data in the database, count is", n, "or error getting count", err)
+	}
+
+	// Search the database.
+	for _, r := range testfilesetup.data {
+		searchval := r["textfield"].(string)
+		t.Log("searchval", searchval)
+		sreq := bleve.NewSearchRequest(bleve.NewTermQuery(searchval))
+		// Note that the result Fields contain only the ones listed here.
+		sreq.Fields = []string{"textfield", "numberfield"}
+
+		searchResults, err := db.Search(sreq)
+		if err != nil {
+			// Is this what lies underneath my error cases.
+			t.Fatal("couldn't search the test database", err)
+			continue
+		}
+
+		f, _ := db.Fields()
+		t.Log("fields:", f)
+
+		if len(searchResults.Hits) != 1 {
+			t.Fatal("expected 1 match for", searchval, "but got", len(searchResults.Hits))
+			continue
+		}
+
+		// check that everything worked.
+		uuid := searchResults.Hits[0].ID
+		doc, err := db.Document(uuid)
+		if err != nil {
+			t.Fatalf("failed to find %v in database: %v", uuid, err)
+		}
+
+		ormdoc, err := MakeMapFromDocument(doc)
+		if err != nil {
+			t.Fatalf("failed to ORM convert %v because %v", ormdoc, err)
+		}
+
+		if got, want := ormdoc["_type"].(string), r["_type"].(string); got != want {
+			t.Errorf("invalid ORM mapping got %v but want %v", got, want)
+		}
+		if got, want := ormdoc["istruefield"].(bool), r["istruefield"].(bool); got != want {
+			t.Errorf("invalid ORM mapping got %v but want %v", got, want)
+		}
+		if got, want := ormdoc["textfield"].(string), r["textfield"].(string); got != want {
+			t.Errorf("invalid ORM mapping got %v but want %v", got, want)
+		}
+		if got, want := ormdoc["numberfield"].(float64), r["numberfield"].(float64); got != want {
+			t.Errorf("invalid ORM mapping got %v but want %v", got, want)
+		}
+		if got, want := ormdoc["datefield"].(time.Time), r["datefield"].(time.Time); !got.Equal(want) {
+			t.Errorf("invalid ORM mapping got %v but want %v", got, want)
+		}
+	}
+}

--- a/dba/fieldmap/comments.go
+++ b/dba/fieldmap/comments.go
@@ -30,13 +30,13 @@ func (p comment) Type() string {
 func buildCommentIndexMapping() *bleve.DocumentMapping {
 	// commentEntryMapping is a document for each comment.
 	commentEntryMapping := bleve.NewDocumentMapping()
-	commentEntryMapping.AddFieldMappingsAt("uuid", keywordFieldMapping)
+	commentEntryMapping.AddFieldMappingsAt("uuid", KeywordFieldMapping)
 	// comment creation date.
 	// comment update date.
 	// the uid of the user.
-	commentEntryMapping.AddFieldMappingsAt("owner", keywordFieldMapping)
+	commentEntryMapping.AddFieldMappingsAt("owner", KeywordFieldMapping)
 	// comments can be vieweable by signed in user ("me", signed-in "volunteers", "world")
-	commentEntryMapping.AddFieldMappingsAt("viewability", keywordFieldMapping)
-	commentEntryMapping.AddFieldMappingsAt("body", englishTextFieldMapping)
+	commentEntryMapping.AddFieldMappingsAt("viewability", KeywordFieldMapping)
+	commentEntryMapping.AddFieldMappingsAt("body", EnglishTextFieldMapping)
 	return commentEntryMapping
 }

--- a/dba/fieldmap/common_mappings.go
+++ b/dba/fieldmap/common_mappings.go
@@ -11,40 +11,40 @@ import (
 type IndexDocumentMap map[string]*bleve.DocumentMapping
 
 // Standard field mappings. Use them everywhere.
-var englishTextFieldMapping *bleve.FieldMapping
-var keywordFieldMapping *bleve.FieldMapping
-var ignoredFieldMapping *bleve.FieldMapping
-var dateTimeMapping *bleve.FieldMapping
-var boolFieldMapping *bleve.FieldMapping
+var EnglishTextFieldMapping *bleve.FieldMapping
+var KeywordFieldMapping *bleve.FieldMapping
+var IgnoredFieldMapping *bleve.FieldMapping
+var DateTimeMapping *bleve.FieldMapping
+var BoolFieldMapping *bleve.FieldMapping
 
 // init makes all of the mappings that we use. A single instance of a
 // mapping such as englishTextMapping can be used for any number of
 // fields.
 func init() {
 	// a generic reusable mapping for english text
-	englishTextFieldMapping = bleve.NewTextFieldMapping()
-	englishTextFieldMapping.Analyzer = en.AnalyzerName
+	EnglishTextFieldMapping = bleve.NewTextFieldMapping()
+	EnglishTextFieldMapping.Analyzer = en.AnalyzerName
 
 	// a generic reusable mapping for keyword text
-	keywordFieldMapping = bleve.NewTextFieldMapping()
-	keywordFieldMapping.Analyzer = keyword_analyzer.Name
+	KeywordFieldMapping = bleve.NewTextFieldMapping()
+	KeywordFieldMapping.Analyzer = keyword_analyzer.Name
 
 	// a generic reusable mapping for ignored content.
-	ignoredFieldMapping = bleve.NewTextFieldMapping()
-	ignoredFieldMapping.Store = false
-	ignoredFieldMapping.Index = false
-	ignoredFieldMapping.IncludeTermVectors = false
-	ignoredFieldMapping.IncludeInAll = false
+	IgnoredFieldMapping = bleve.NewTextFieldMapping()
+	IgnoredFieldMapping.Store = false
+	IgnoredFieldMapping.Index = false
+	IgnoredFieldMapping.IncludeTermVectors = false
+	IgnoredFieldMapping.IncludeInAll = false
 
 	// a date/time mapping
 	// I believe that this is good like this. I will have to experiment.
-	dateTimeMapping = bleve.NewDateTimeFieldMapping()
+	DateTimeMapping = bleve.NewDateTimeFieldMapping()
 
 	// a generic reusable mapping for booleans
-	boolFieldMapping = bleve.NewBooleanFieldMapping()
+	BoolFieldMapping = bleve.NewBooleanFieldMapping()
 }
 
-// allDocumentMapping creates a new top-level mapping for an entire database
+// AllDocumentMapping creates a new top-level mapping for an entire database
 // from the provided map of per-document mappings. (Per Bleve terminology, the
 // database is conceptually an array of documents with an index of the document
 // contents that permits finding sets of documents. In sfsbook, the fundamental
@@ -54,7 +54,7 @@ func init() {
 // Each document must have a _type key that specifies this key value in order
 // to select the type of the document. Features like comments and edit auditing
 // will introduce additional document types.
-func allDocumentMapping(docMappings IndexDocumentMap) *bleve.IndexMapping {
+func AllDocumentMapping(docMappings IndexDocumentMap) *bleve.IndexMapping {
 	indexMapping := bleve.NewIndexMapping()
 
 	for k, v := range docMappings {

--- a/dba/fieldmap/passwords.go
+++ b/dba/fieldmap/passwords.go
@@ -36,12 +36,12 @@ func buildPasswordEntryMapping() *bleve.DocumentMapping {
 	passwordEntryMapping := bleve.NewDocumentMapping()
 
 	passwordEntryMapping.DefaultAnalyzer = keyword_analyzer.Name
-	passwordEntryMapping.AddFieldMappingsAt("username", keywordFieldMapping)
+	passwordEntryMapping.AddFieldMappingsAt("username", KeywordFieldMapping)
 	passwordEntryMapping.AddFieldMappingsAt("passwordhash", passwordFieldMapping)
 	passwordEntryMapping.AddFieldMappingsAt("cost", costFieldMapping)
-	passwordEntryMapping.AddFieldMappingsAt("account_created", dateTimeMapping)
-	passwordEntryMapping.AddFieldMappingsAt("last_login", dateTimeMapping)
-	passwordEntryMapping.AddFieldMappingsAt("display_name", keywordFieldMapping)
+	passwordEntryMapping.AddFieldMappingsAt("account_created", DateTimeMapping)
+	passwordEntryMapping.AddFieldMappingsAt("last_login", DateTimeMapping)
+	passwordEntryMapping.AddFieldMappingsAt("display_name", KeywordFieldMapping)
 
 	return passwordEntryMapping
 }
@@ -54,7 +54,7 @@ func (g PasswordFileType) Name() string {
 }
 
 func (_ PasswordFileType) Mapping() *bleve.IndexMapping {
-	return allDocumentMapping(IndexDocumentMap{
+	return AllDocumentMapping(IndexDocumentMap{
 		"password": buildPasswordEntryMapping(),
 	})
 }

--- a/dba/fieldmap/passwords_test.go
+++ b/dba/fieldmap/passwords_test.go
@@ -40,9 +40,9 @@ func TestPasswordFile(t *testing.T) {
 
 	// Search the database.
 	for _, uname_passwd := range [][]string{
-				[]string{"admin", "sesame", "admin", "Pokemon Guardian"}, 
-				[]string{"volunteer", "open", "volunteer", "Pikachu Helper"},
-			} {
+		[]string{"admin", "sesame", "admin", "Pokemon Guardian"},
+		[]string{"volunteer", "open", "volunteer", "Pikachu Helper"},
+	} {
 		uname := uname_passwd[0]
 		sreq := bleve.NewSearchRequest(bleve.NewMatchQuery(uname))
 		// Note that the result only contains the fields specified here.
@@ -82,7 +82,6 @@ func TestPasswordFile(t *testing.T) {
 		if got, want := sr.Fields["display_name"].(string), uname_passwd[3]; got != want {
 			t.Error("display_name wrong got", got, "want", want)
 		}
-		
+
 	}
 }
-

--- a/dba/fieldmap/resources.go
+++ b/dba/fieldmap/resources.go
@@ -22,25 +22,25 @@ func buildResourceDocumentMapping() *bleve.DocumentMapping {
 
 	// With a default analyzer specified, we don't need to list the english field mappings.
 	// resourceEntryMapping.AddFieldMappingsAt("uuid", keywordFieldMapping)
-	resourceEntryMapping.AddFieldMappingsAt("email", keywordFieldMapping)
+	resourceEntryMapping.AddFieldMappingsAt("email", KeywordFieldMapping)
 
 	// TODO(rjk): Support the indexing of the hand_sort later. At the moment, this is not
 	// well structured. Later code will use the better-structured version of the data found
 	// in the csv.
-	resourceEntryMapping.AddFieldMappingsAt("hand_sort", ignoredFieldMapping)
-	resourceEntryMapping.AddFieldMappingsAt("website", keywordFieldMapping)
+	resourceEntryMapping.AddFieldMappingsAt("hand_sort", IgnoredFieldMapping)
+	resourceEntryMapping.AddFieldMappingsAt("website", KeywordFieldMapping)
 
 	// I note in passing that this can be populated from the hand_sort data.
 	// I might consider adding additional code to automatically freshen the data.
-	resourceEntryMapping.AddFieldMappingsAt("wheelchair", ignoredFieldMapping)
+	resourceEntryMapping.AddFieldMappingsAt("wheelchair", IgnoredFieldMapping)
 
 	// To track if we have been reviewed.
-	resourceEntryMapping.AddFieldMappingsAt("reviewed", boolFieldMapping)
+	resourceEntryMapping.AddFieldMappingsAt("reviewed", BoolFieldMapping)
 
 	// Time when this resource was first added to the database and last modified.
 	// TODO(rjk): Note need to track the edits.
-	resourceEntryMapping.AddFieldMappingsAt("date_indexed", dateTimeMapping)
-	resourceEntryMapping.AddFieldMappingsAt("date_modified", dateTimeMapping)
+	resourceEntryMapping.AddFieldMappingsAt("date_indexed", DateTimeMapping)
+	resourceEntryMapping.AddFieldMappingsAt("date_modified", DateTimeMapping)
 
 	return resourceEntryMapping
 }
@@ -54,7 +54,7 @@ func (g RefGuideType) Name() string {
 }
 
 func (_ RefGuideType) Mapping() *bleve.IndexMapping {
-	return allDocumentMapping(IndexDocumentMap{
+	return AllDocumentMapping(IndexDocumentMap{
 		"resource": buildResourceDocumentMapping(),
 	})
 }
@@ -62,7 +62,7 @@ func (_ RefGuideType) Mapping() *bleve.IndexMapping {
 var RefGuide = RefGuideType("sfsbook.bleve")
 
 func (_ RefGuideType) LoadStartData(i bleve.Index, pathroot string) error {
-	log.Println("Indexing... now")
+	log.Println("RefGuideType LoadStartData")
 
 	jsonBytes, err := ioutil.ReadFile(filepath.Join(pathroot, sourcefile))
 	if err != nil {

--- a/dba/open_dba.go
+++ b/dba/open_dba.go
@@ -41,7 +41,7 @@ func OpenBleve(persistentroot string, dxf IndexFactory) (bleve.Index, error) {
 			goto cleanup
 		}
 
-		// Re-open to work-around KV not done writing.		
+		// Re-open to work-around KV not done writing.
 		if bi, err = bleve.Open(dbpath); err != nil {
 			goto cleanup
 		}

--- a/dba/resource_generator.go
+++ b/dba/resource_generator.go
@@ -81,7 +81,7 @@ func (qr *ResourceResultsGenerator) ForRequest(req interface{}) GeneratedResult 
 		return results
 	}
 
-	resultsMap, err := resultsMapFromDocument(doc)
+	resultsMap, err := MakeMapFromDocument(doc)
 	if err != nil {
 		log.Println("couldn't convert doc to resultsMap")
 		results.generatedResultCore.failureText = err.Error()


### PR DESCRIPTION
I noted that the ORM module that I was using for resource guide entries
was generally applicable in other contexts so made it general and added
a unit test to show that it handles all current types that we support
as document fields.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfbrigade/sfsbook/76)
<!-- Reviewable:end -->
