### PR TITLE
Remove layering violation in password searching

### DIFF
--- a/dba/password_index.go
+++ b/dba/password_index.go
@@ -1,7 +1,12 @@
 package dba
 
 import (
+	"log"
+	"strconv"
+
 	"github.com/blevesearch/bleve"
+	"github.com/blevesearch/bleve/search/query"
+	"github.com/pborman/uuid"
 )
 
 // PasswordIndex is a minimal set of entry points into bleve.Index
@@ -15,14 +20,20 @@ type PasswordIndex interface {
 	// and returns a search result.
 	Search(req *bleve.SearchRequest) (*bleve.SearchResult, error)
 
+	// ListUsers searches the password database for the specified match string and
+	// returns a list of users of not more than size entries starting from
+	// from in the result lis or error.
+	// TODO(rjk): Figure out if I want to specify the fields.
+	ListUsers(userquery string, size, from int) ([]map[string]interface{}, error)
+
 	// Returns the document map for a given document (i.e. password entry)
 	// when presented with the entry's UUID
-	// TODO(rjk): Make sure that the returned map can be indexed. 
+	// TODO(rjk): Make sure that the returned map can be indexed.
 	// And maybe give these better names. And use UUIDs for type clarity.
 	MapForDocument(id string) (map[string]interface{}, error)
 
 	// Deletes the specificed password entry.
-	Delete (id string) error
+	Delete(id string) error
 }
 
 type blevePasswordIndex struct {
@@ -39,14 +50,62 @@ func (pdoc *blevePasswordIndex) MapForDocument(id string) (map[string]interface{
 }
 
 // TODO(rjk): Fix the layering violation of leaking bleve into the interface.
+// Update: ListUsers resolves this in part.
 func (pdoc *blevePasswordIndex) Search(req *bleve.SearchRequest) (*bleve.SearchResult, error) {
 	return pdoc.idx.Search(req)
+}
+
+func (pdoc *blevePasswordIndex) ListUsers(userquery string, size, from int) ([]map[string]interface{}, error) {
+	log.Println("called ListUsers", userquery, size, from)
+
+	var queryop query.Query
+	if userquery == "" {
+		queryop = bleve.NewMatchAllQuery()
+	} else {
+		queryop = bleve.NewWildcardQuery(userquery)
+	}
+
+	sreq := bleve.NewSearchRequest(queryop)
+	sreq.Fields = []string{"name", "role", "display_name"}
+	sreq.Size = size
+	sreq.From = from
+
+	rawresults, err := pdoc.idx.Search(sreq)
+	if err != nil {
+		log.Println("error in search", err)
+		return nil, err
+	}
+
+	if len(rawresults.Hits) < 1 {
+		log.Println("no users in search")
+		return make([]map[string]interface{}, 0, 0), nil
+	}
+	users := make([]map[string]interface{}, 0, len(rawresults.Hits))
+
+	for i, sr := range rawresults.Hits {
+		u := make(map[string]interface{})
+		for k, v := range sr.Fields {
+			// Could test and drop the unfortunate?
+			u[k] = v.(string)
+		}
+
+		uuidcasted := uuid.UUID(sr.ID)
+		// I thought about encrypting the UUIDs. But to get this content, one
+		// must already have the admin role and that is enforced server side
+		// via a strongly encrypted cookie. And they are cryptographically
+		// difficult to guess already.
+		u["uuid"] = uuidcasted.String()
+
+		// It's conceivable that offsetting this by where we are in the list is foolish.
+		u["index"] = strconv.FormatInt(int64(i+from), 10)
+		users = append(users, u)
+	}
+	return users, nil
 }
 
 func (pdoc *blevePasswordIndex) Delete(id string) error {
 	return pdoc.idx.Delete(id)
 }
-
 
 func (pdoc *blevePasswordIndex) Index(id string, data interface{}) error {
 	return pdoc.idx.Index(id, data)

--- a/server/listusers.go
+++ b/server/listusers.go
@@ -4,11 +4,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"strconv"
 	"strings"
 
-	"github.com/blevesearch/bleve"
-	"github.com/blevesearch/bleve/search/query"
 	"github.com/pborman/uuid"
 	"github.com/sfbrigade/sfsbook/dba"
 )
@@ -104,10 +101,8 @@ func (gs *listUsers) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	var queryop query.Query
-	queryop = bleve.NewMatchAllQuery()
-
 	// Setup a query. The query is different if we have specified it.
+	userquery := ""
 	log.Println("not a post but proceeding anyway")
 	log.Println("req", req)
 
@@ -158,14 +153,14 @@ func (gs *listUsers) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		case k == "deleteuser":
 			action = _DELETEUSERS
 		case k == "userquery":
-			userquery, err := getValidatedString("userquery", req.Form)
+			uq, err := getValidatedString("userquery", req.Form)
 			if err != nil {
 				log.Println("no userquery", err)
 				listusersresult.Diagnosticmessage = "Showing all..."
 			} else {
 				// We had an argument to search with.
-				listusersresult.Userquery = userquery
-				queryop = bleve.NewWildcardQuery(userquery)
+				listusersresult.Userquery = uq
+				userquery = uq
 				// TODO(rjk): Improve database indexing.
 			}
 		case k == "resetpassword":
@@ -215,49 +210,19 @@ func (gs *listUsers) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// And now do the search.
-
-	// I need to make this search the right way. And bound the result set
-	// size.
-	sreq := bleve.NewSearchRequest(queryop)
-	sreq.Fields = []string{"name", "role", "display_name"}
-
-	// These two values need to come from the URL args so that I can
-	// page through many users.
-	sreq.Size = 10
-	sreq.From = 0
-
-	// This is an error case (something is wrong internally)
-	searchResults, err := gs.passwordfile.Search(sreq)
+	users, err := gs.passwordfile.ListUsers(userquery, 10, 0)
 	if err != nil {
 		respondWithError(w, fmt.Sprintln("database couldn't respond with useful results", err))
 		return
 	}
-
-	if len(searchResults.Hits) < 1 {
+	if len(users) < 1 {
 		// This probably means that the user has entered an invalid query.
+		// Or that we've paged past the end.
 		listusersresult.Diagnosticmessage = "Userquery matches no users."
 		gs.ender(w, req, listusersresult)
 		return
 	}
 
-	users := make([]map[string]interface{}, 0, len(searchResults.Hits))
-	for i, sr := range searchResults.Hits {
-		u := make(map[string]interface{})
-		for k, v := range sr.Fields {
-			// Could test and drop the unfortunate?
-			u[k] = v.(string)
-		}
-
-		uuidcasted := uuid.UUID(sr.ID)
-		// I thought about encrypting the UUIDs. But to get this content, one
-		// must already have the admin role and that is enforced server side
-		// via a strongly encrypted cookie. And they are cryptographically
-		// difficult to guess already.
-		u["uuid"] = uuidcasted.String()
-		u["index"] = strconv.FormatInt(int64(i), 10)
-		users = append(users, u)
-	}
 	listusersresult.Querysuccess = true
 	listusersresult.Users = users
 

--- a/server/mockpassword_test.go
+++ b/server/mockpassword_test.go
@@ -44,6 +44,10 @@ func (tape *mockPasswordIndex) Search(_ *bleve.SearchRequest) (*bleve.SearchResu
 	return nil, fmt.Errorf("not-implemented")
 }
 
+func (tape *mockPasswordIndex) ListUsers(userquery string, size, from int) ([]map[string]interface{}, error) {
+	return nil, fmt.Errorf("not-implemented")
+}
+
 func (tape *mockPasswordIndex) Delete(id string) error {
 	return fmt.Errorf("not-implemented")
 }


### PR DESCRIPTION
The code in listusers.go reaches directly into bleve to list
passwords. This is a layering violation that impedes testing. Refactor
this code out of listusers.go and move the ORM functionality into the
dba layer instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfbrigade/sfsbook/98)
<!-- Reviewable:end -->
