### PR TITLE
adds makefile for common tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+
+help:
+	@echo Available targets are listed in the Makefile:
+	@cat Makefile
+
+build:
+	go get
+	go build
+
+start:
+	./sfsbook -init_passwords
+
+open:
+	open "https://localhost:10443/index.html" #works on Mac
+
+clean:
+	rm -f state/{*.dat,*.pem}
+	rm -rf state/{*.bleve}


### PR DESCRIPTION
Resolves #121 

Hopefully self explanatory, but now you can run:

```
make clean
``` 

to clean state (like the database files), and 

```
make build start
```

to build and then start, and in another terminal just

```
make open
```

to open your browser to the index page.