### PR TITLE
Below 500px width breakpoint, remove margin on search

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -701,4 +701,8 @@ textarea {
   .search-filter-container ul {
     width: 120px;
   }
+  #search-form {
+    margin-right: 0;
+    margin-left: 0;
+  }
 }


### PR DESCRIPTION
Fixes #113 

Above 500px:
![image](https://cloud.githubusercontent.com/assets/1072292/24031228/b62d44f0-0a9e-11e7-88fb-4da20ea6cb87.png)

Below 500px (note the reduced margin):
![image](https://cloud.githubusercontent.com/assets/1072292/24031238/c241cf0e-0a9e-11e7-9c46-05aefb5fbfff.png)

